### PR TITLE
Add sample indicator and histograms to selection analysis

### DIFF
--- a/R/auditCommonFunctions.R
+++ b/R/auditCommonFunctions.R
@@ -2598,7 +2598,9 @@
 
   selectionContainer[["plotHistograms"]] <- plotHistograms
 
-  if(options[["recordNumberVariable"]] == "" || options[["monetaryVariable"]] == "")
+  if(options[["recordNumberVariable"]] == "" || 
+      options[["monetaryVariable"]] == "" || 
+      options[["sampleSize"]] == 0)
     return()
 
   variables <- colnames(selectionState)[-(1:3)]

--- a/inst/help/auditselection.md
+++ b/inst/help/auditselection.md
@@ -11,6 +11,9 @@ Default input options
 #### Sample size
 The required sample size that should be selected from the population. 
 
+#### Add selection counter to data
+When enabled, adds the result from the selection analysis in a new column to the data. The new column reflects how many times each transaction is included in the sample.
+
 ----
 
 Advanced input options
@@ -55,6 +58,14 @@ Produces a table containing the selected observations along with any additional 
 
 #### Selection descriptives
 Produces a table containing descriptive information about numerical variables in the selection.
+
+----
+
+Advanced output (plots)
+-------
+
+#### Population and sample histograms
+Produces an overlapping histogram that compares the distribution of values of each variable in the population to the values in the sample.
 
 ----
 

--- a/inst/help/auditselection_nl.md
+++ b/inst/help/auditselection_nl.md
@@ -11,6 +11,9 @@ Standaard invoeropties
 #### Steekproefgrootte
 Het benodigde aantal steekproefelementen dat geselecteerd wordt uit de populatie.
 
+#### Voeg selectie uitkomst toe aan data
+Wanneer ingeschakeld voegt de analyse het resultaat van de selectieanalyse in een nieuwe kolom toe aan de data. De nieuwe kolom geeft weer hoe vaak elke transactie in de steekproef is opgenomen.
+
 ----
 
 Geavanceerde invoeropties
@@ -55,6 +58,14 @@ Produceert een tabel met de geselecteerde waarnemingen samen met eventuele aanvu
 
 #### Selectie samenvatting
 Produceert een tabel met beschrijvende informatie over numerieke variabelen in de steekproef.
+
+----
+
+Geavanceerde resultaten (plots)
+-------
+
+#### Populatie en steekproef histogrammen
+Produceert een overlappend histogram dat de verdeling van waarden van elke variabele in de populatie vergelijkt met de waarden in de steekproef.
 
 ----
 

--- a/inst/help/auditselection_nl.md
+++ b/inst/help/auditselection_nl.md
@@ -11,7 +11,7 @@ Standaard invoeropties
 #### Steekproefgrootte
 Het benodigde aantal steekproefelementen dat geselecteerd wordt uit de populatie.
 
-#### Voeg selectie uitkomst toe aan data
+#### Voeg selectie teller toe aan data
 Wanneer ingeschakeld voegt de analyse het resultaat van de selectieanalyse in een nieuwe kolom toe aan de data. De nieuwe kolom geeft weer hoe vaak elke transactie in de steekproef is opgenomen.
 
 ----

--- a/inst/qml/auditSelection.qml
+++ b/inst/qml/auditSelection.qml
@@ -265,8 +265,8 @@ Form {
 				CheckBox { 
 					text: qsTr("Population and sample histograms")
 					name: "plotHistograms"
-					enabled: recordNumberVariable.count > 0					
-					}
+					enabled: recordNumberVariable.count > 0	& monetaryVariable.count > 0				
+				}
 
 			}
 		}

--- a/inst/qml/auditSelection.qml
+++ b/inst/qml/auditSelection.qml
@@ -210,7 +210,7 @@ Form {
 
 	Section
 	{
-		title: 												qsTr("Tables")
+		title: 												qsTr("Tables and Plots")
 
 		GridLayout
 		{
@@ -256,7 +256,36 @@ Form {
 					}
 				}
 			}
+
+			GroupBox
+			{
+				id: 											samplingPlots
+				title: 										qsTr("Plots")
+
+				CheckBox { 
+					text: qsTr("Population and sample histograms")
+					name: "plotHistograms"
+					enabled: recordNumberVariable.count > 0					
+					}
+
+			}
 		}
+	}
+
+	CheckBox 
+	{ 
+			id: addSampleIndicator  
+			name: "addSampleIndicator"
+			text: qsTr("Add selection counter to data")
+			enabled: recordNumberVariable.count > 0
+
+			ComputedColumnField 
+			{ 
+					name: 			"sampleIndicatorColumn"
+					text: 			qsTr("Column name: ")
+					fieldWidth: 120
+					visible:    addSampleIndicator.checked
+			}
 	}
 
 	Item


### PR DESCRIPTION
This PR implements some additions to the Audit module, and in specific to the selection analysis.
Concretely:

- There is now a computed column that adds the result of the selection analysis to the data set
- I have added plots that compare the distribution of values in the population to those in the resulting sample.

I haven't tested the unit tests and importing the module separately, since it has a qml file as description.